### PR TITLE
added codetour extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"vsls-contrib.codetour"
+	]
+}


### PR DESCRIPTION
so that you can follow the codetour from vscode.dev: https://vscode.dev/github/chanezon/posedance